### PR TITLE
chore: rename chart to casdoor

### DIFF
--- a/charts/casdoor/Chart.yaml
+++ b/charts/casdoor/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: casdoor-helm-charts
+name: casdoor
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
**Description**
- Rename Helm Chart to casdoor

**Why**
- When the helm chart is deployed in kubernetes, it's listed in the following format `casdoor-helm-charts-9c45egzb6d-96ghr` where `9c45egzb6d-96ghr` is a generated pod suffix id by kubernetes
- Would be better to have it named `casdoor-9c45egzb6d-96ghr` instead
- Other helm charts (e.g. airflow) follow this format and do not list the word helm-chart

**Version Updates?**
- Not required as the next deployment from casdoor main repo will increment the version on our behalf