### PR TITLE
fix: add package.json for ci release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
+    "semantic-release": "^22.0.5"
+  }
+}


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-helm/issues/12

- fix ci by adding package.json containing semantic references