### PR TITLE
feat: add `database`

### DIFF
--- a/charts/casdoor/templates/_helpers.tpl
+++ b/charts/casdoor/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Create dataSourceName used in the configmap
 {{- define "casdoor.dataSourceName" -}}
 {{- if eq .Values.database.driver "mysql" -}}
 {{ .Values.database.user }}:{{ .Values.database.password }}@tcp({{ .Values.database.host }}:{{ default "3306" .Values.database.port }})/
-{{- else if eq .Values.database.driver "postgresql" -}}
+{{- else if eq .Values.database.driver "postgres" -}}
 "user={{ .Values.database.user }} password={{ .Values.database.password }} host={{ .Values.database.host }} port={{ default "5432" .Values.database.port }} dbname={{ .Values.database.databaseName }} sslmode={{ .Values.database.sslMode }}"
 {{- else if eq .Values.database.driver "cockroachdb" -}}
 "user={{ .Values.database.user }} password={{ .Values.database.password }} host={{ .Values.database.host }} port={{ default "26257" .Values.database.port }} dbname={{ .Values.database.databaseName }} sslmode={{ .Values.database.sslMode }} serial_normalization=virtual_sequence"
@@ -82,7 +82,7 @@ Create dbName used in the configmap
 {{- define "casdoor.dbName" -}}
 {{- if eq .Values.database.driver "mysql" -}}
 {{ .Values.database.databaseName }}
-{{- else if eq .Values.database.driver "postgresql" -}}
+{{- else if eq .Values.database.driver "postgres" -}}
 {{- else if eq .Values.database.driver "cockroachdb" -}}
 {{- else -}}
 {{ .Values.database.databaseName }}

--- a/charts/casdoor/templates/_helpers.tpl
+++ b/charts/casdoor/templates/_helpers.tpl
@@ -60,3 +60,31 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create dataSourceName used in the configmap
+*/}}
+{{- define "casdoor.dataSourceName" -}}
+{{- if eq .Values.database.driver "mysql" -}}
+{{ .Values.database.user }}:{{ .Values.database.password }}@tcp({{ .Values.database.host }}:{{ default "3306" .Values.database.port }})/
+{{- else if eq .Values.database.driver "postgresql" -}}
+"user={{ .Values.database.user }} password={{ .Values.database.password }} host={{ .Values.database.host }} port={{ default "5432" .Values.database.port }} dbname={{ .Values.database.databaseName }} sslmode={{ .Values.database.sslMode }}"
+{{- else if eq .Values.database.driver "cockroachdb" -}}
+"user={{ .Values.database.user }} password={{ .Values.database.password }} host={{ .Values.database.host }} port={{ default "26257" .Values.database.port }} dbname={{ .Values.database.databaseName }} sslmode={{ .Values.database.sslMode }} serial_normalization=virtual_sequence"
+{{- else -}}
+file:casdoor.db?cache=shared
+{{- end }}
+{{- end }}
+
+{{/*
+Create dbName used in the configmap
+*/}}
+{{- define "casdoor.dbName" -}}
+{{- if eq .Values.database.driver "mysql" -}}
+{{ .Values.database.databaseName }}
+{{- else if eq .Values.database.driver "postgresql" -}}
+{{- else if eq .Values.database.driver "cockroachdb" -}}
+{{- else -}}
+{{ .Values.database.databaseName }}
+{{- end }}
+{{- end }}

--- a/charts/casdoor/templates/configmap.yaml
+++ b/charts/casdoor/templates/configmap.yaml
@@ -5,4 +5,5 @@ metadata:
   labels:
     {{- include "casdoor.labels" . | nindent 4 }}
 data:
-  app.conf: {{ tpl .Values.config . | toYaml | nindent 4 }}
+  app.conf: |
+    {{- tpl .Values.config . | nindent 4 }}

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -33,14 +33,14 @@ config: |
   enableGzip = true
 
 database:
-  # Supports mysql, postgresql, cockroachdb, sqlite3
+  # Supports mysql, postgres, cockroachdb, sqlite3
   driver: sqlite3
 
   user: ""
   password: ""
   host: ""
   # If port is empty, default port will be used.
-  # mysql: 3306, postgresql: 5432, cockroachdb: 26257
+  # mysql: 3306, postgres: 5432, cockroachdb: 26257
   port: ""
   databaseName: casdoor
 

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -18,9 +18,9 @@ config: |
   runmode = dev
   SessionOn = true
   copyrequestbody = true
-  driverName = sqlite
-  dataSourceName = "file:ent?mode=memory&cache=shared&_fk=1"
-  dbName = casdoor
+  driverName = {{ .Values.database.driver }}
+  dataSourceName = {{ include "casdoor.dataSourceName" . }}
+  dbName = {{ include "casdoor.dbName" . }}
   redisEndpoint =
   defaultStorageProvider =
   isCloudIntranet = false
@@ -31,6 +31,20 @@ config: |
   logPostOnly = true
   origin =
   enableGzip = true
+
+database:
+  # Supports mysql, postgresql, cockroachdb, sqlite3
+  driver: sqlite3
+
+  user: ""
+  password: ""
+  host: ""
+  # If port is empty, default port will be used.
+  # mysql: 3306, postgresql: 5432, cockroachdb: 26257
+  port: ""
+  databaseName: casdoor
+
+  sslMode: disable
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
I wanted to make it easier to set up the database, so I added `database` to values.yaml.

## Example

### MySQL

```yaml
database:
  driver: mysql

  user: root
  password: 123456
  host: localhost
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: casdoor-casdoor-helm-charts-config
data:
  app.conf: |
    ...
    driverName = mysql
    dataSourceName = root:123456@tcp(localhost:3306)/
    dbName = casdoor
    ...
```

### PostgreSQL

```yaml
database:
  driver: postgres

  user: postgres
  password: postgres
  host: localhost
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: casdoor-casdoor-helm-charts-config
data:
  app.conf: |
    ...
    driverName = postgres
    dataSourceName = "user=postgres password=postgres host=localhost port=5432 dbname=casdoor sslmode=disable"
    dbName = 
    ...
```

### CockroachDB

```yaml
database:
  driver: cockroachdb

  user: maxroach
  password: maxroach
  host: localhost
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: casdoor-casdoor-helm-charts-config
data:
  app.conf: |
    ...
    driverName = cockroachdb
    dataSourceName = "user=maxroach password=maxroach host=localhost port=26257 dbname=casdoor sslmode=disable serial_normalization=virtual_sequence"
    dbName = 
    ...
```

### SQLite3

```yaml
database:
  driver: sqlite3
```

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: casdoor-casdoor-helm-charts-config
data:
  app.conf: |
    ...
    driverName = sqlite3
    dataSourceName = file:casdoor.db?cache=shared
    dbName = casdoor
    ...
```