### PR TITLE
feat: support envFrom

### DIFF
--- a/charts/casdoor/templates/_helpers.tpl
+++ b/charts/casdoor/templates/_helpers.tpl
@@ -88,3 +88,29 @@ Create dbName used in the configmap
 {{ .Values.database.databaseName }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create EnvfromConfigmap
+*/}}
+{{- define "casdoor.envFromConfigmap" -}}
+{{- range . -}}
+- name: {{ .name }}
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .configmapName }}
+      key: {{ .key }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Create EnvfromSecret
+*/}}
+{{- define "casdoor.envFromSecret" -}}
+{{- range . -}}
+- name: {{ .name }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .secretName }}
+      key: {{ .key }}
+{{- end -}}
+{{- end }}

--- a/charts/casdoor/templates/_helpers.tpl
+++ b/charts/casdoor/templates/_helpers.tpl
@@ -113,4 +113,20 @@ Create EnvfromSecret
       name: {{ .secretName }}
       key: {{ .key }}
 {{- end -}}
-{{- end }}
+{{- end -}}
+
+{{/*
+Create Envfrom
+*/}}
+{{- define "casdoor.envFrom" -}}
+{{- range . -}}
+{{- if eq .type "configmap" -}}
+- configMapRef:
+    name: {{ .name }}
+{{ end }}
+{{- if eq .type "secret" -}}
+- secretRef:
+    name: {{ .name }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           {{ if .Values.envFromConfigmap }}
             {{ include "casdoor.envFromConfigmap" .Values.envFromConfigmap | indent 12 | trim }}
           {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{ include "casdoor.envFrom" .Values.envFrom | indent 12 | trim }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -38,6 +38,12 @@ spec:
           env:
             - name: RUNNING_IN_DOCKER
               value: "true"
+          {{- if .Values.envFromSecret }}
+            {{ include "casdoor.envFromSecret" .Values.envFromSecret | indent 12 | trim }}
+          {{- end -}}
+          {{ if .Values.envFromConfigmap }}
+            {{ include "casdoor.envFromConfigmap" .Values.envFromConfigmap | indent 12 | trim }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -131,3 +131,13 @@ extraContainers: ""
 #    image: ...
 extraVolumeMounts: []
 extraVolumes: []
+
+envFromSecret: []
+  # - name: ENV_NAME
+  #   secretName: test-secret
+  #   key: key_name
+
+envFromConfigmap: []
+  # - name: ENV_NAME
+  #   configmapName: test-cm
+  #   key: key_name

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -141,3 +141,9 @@ envFromConfigmap: []
   # - name: ENV_NAME
   #   configmapName: test-cm
   #   key: key_name
+
+envFrom: []
+  # - type: configmap
+  #   name: test-cm
+  # - type: secret
+  #   name: test-secret


### PR DESCRIPTION
This feature is required because some ENV are credentials needed to inject from k8s secret resource.