### PR TITLE
fix: unknown driver sqlite3

### DIFF
--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -33,8 +33,8 @@ config: |
   enableGzip = true
 
 database:
-  # Supports mysql, postgres, cockroachdb, sqlite3
-  driver: sqlite3
+  # Supports mysql, postgres, cockroachdb, sqlite
+  driver: sqlite
 
   user: ""
   password: ""


### PR DESCRIPTION
```
panic: sql: unknown driver "sqlite3" (forgotten import?)
goroutine 1 [running]:
github.com/casdoor/casdoor/object.InitAdapter()
	/go/src/casdoor/object/ormer.go:98 +0x23b
main.main()
	/go/src/casdoor/main.go:35 +0x30
```