### PR TITLE
feat: add initContainers support

### DIFF
--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       serviceAccountName: {{ include "casdoor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{ if .Values.initContainersEnabled }}
+          {{- .Values.initContainers | nindent 6 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -123,6 +123,13 @@ tolerations: []
 
 affinity: {}
 
+# -- Optionally add init containers.
+initContainersEnabled: false
+initContainers: ""
+# initContainers: |
+#  - name: ...
+#    image: ...
+
 # -- Optionally add extra sidecar containers.
 extraContainersEnabled: false
 extraContainers: ""


### PR DESCRIPTION
Allow operators with specific infrastructures requirements to more easily launch casdoor instance.

Exemple:
Operators with light and ephemeral kubernetes cluster for dev and tests may use local based storage instead of a more advanced CSI.
This feature allow them to prepare in advance the volumes access rights according to casdoor container user needs.

Fix: https://github.com/casdoor/casdoor-helm/issues/26