### PR TITLE
feat: add priority class

### DIFF
--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         {{ if .Values.initContainersEnabled }}
           {{- .Values.initContainers | nindent 6 }}
         {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -160,3 +160,5 @@ envFrom: []
   #   name: test-cm
   # - type: secret
   #   name: test-secret
+
+priorityClassName: ""


### PR DESCRIPTION
As account service is critical, having `priorityClassName` in the Casdoor deployment would be beneficial.