### PR TITLE
feat: apply tpl to initcontainers to support variable evaluation

### DIFF
--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
       serviceAccountName: {{ include "casdoor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
         {{ if .Values.initContainersEnabled }}
-          {{- .Values.initContainers | nindent 6 }}
+      initContainers:
+          {{- tpl .Values.initContainers . | nindent 8 }}
         {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-helm/issues/33

apply tpl to initContainers and reorder condition to initContainers for correct rendering. 


helm template before:

```
      ...
      
      securityContext:
        {}
      initContainers:
        
        - name: test
          image: ...
        
      containers:
        - name: casdoor-helm-charts
          securityContext:
          
          ...
```

helm template after:

```
     ...
     
      securityContext:
        {}
        
      initContainers:
        - name: test
          image: ...
        
      containers:
        - name: casdoor-helm-charts
          securityContext:
          
          ...

```