### PR TITLE
fix: Make default config volume mounting optional

### DIFF
--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -79,8 +79,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.defaultConfigVolumeEnabled }}
             - name: config-volume
               mountPath: /conf
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -88,6 +90,7 @@ spec:
           {{- .Values.extraContainers | nindent 8 }}
         {{- end }}
       volumes:
+        {{- if .Values.defaultConfigVolumeEnabled }}
         - name: config-volume
           projected:
             defaultMode: 420
@@ -105,6 +108,7 @@ spec:
                     - key: app.conf
                       path: app.conf
             {{- end }}
+        {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -33,7 +33,7 @@ config: |
   enableGzip = true
   ldapServerPort = 10389
 
-# Use secret to mount app.conf file for who don't want user,pass on git  
+# Use secret to mount app.conf file for who don't want user,pass on git
 # encode base64 on Value.config or create your own secret with anything you prefer
 # if you use your own secret, leave Value.config: ""
 # configFromSecret: casdoor
@@ -72,10 +72,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -96,7 +98,8 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -109,7 +112,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -150,20 +154,27 @@ extraContainers: ""
 extraVolumeMounts: []
 extraVolumes: []
 
-envFromSecret: []
+envFromSecret:
+  []
   # - name: ENV_NAME
   #   secretName: test-secret
   #   key: key_name
 
-envFromConfigmap: []
+envFromConfigmap:
+  []
   # - name: ENV_NAME
   #   configmapName: test-cm
   #   key: key_name
 
-envFrom: []
+envFrom:
+  []
   # - type: configmap
   #   name: test-cm
   # - type: secret
   #   name: test-secret
 
 priorityClassName: ""
+
+# -- Enable/disable the default config volume mount to /conf
+# Set to false if you want to provide your own config volume via extraVolumes/extraVolumeMounts
+defaultConfigVolumeEnabled: true


### PR DESCRIPTION
Summary
This PR introduces a new configuration option `defaultConfigVolumeEnabled` that allows users to disable the default config volume mounting behavior, enabling them to provide their own custom config volume configuration via `extraVolumes` and `extraVolumeMounts`.

### Motivation
Currently, the Helm chart hardcodes the mounting of a `config-volume` to `/conf`, which creates limitations for users who need:
- Custom config volume sources (e.g., existing PVCs, external secret management)
- Integration with HashiCorp Vault Agent Injector for secret management
- More complex volume configurations (e.g., multiple config files from different sources)
- Different mounting paths or volume configurations
- External config management systems

Without this change, users cannot fully customize the config volume behavior since the default volume mount conflicts with or overrides their custom configurations.

### Changes
- **Added `defaultConfigVolumeEnabled` flag** in `values.yaml` (defaults to `true` for backward compatibility)
- **Made config volume mount conditional** in `deployment.yaml` template
- **Made config volume definition conditional** in `deployment.yaml` template
- **Added comprehensive documentation** for the new configuration option

### Usage Examples

#### Using existing PVC for config:
```yaml
defaultConfigVolumeEnabled: false

extraVolumes:
  - name: casdoor-config-pvc
    persistentVolumeClaim:
      claimName: casdoor-config-storage

extraVolumeMounts:
  - name: casdoor-config-pvc
    mountPath: /conf
    readOnly: true
```

#### Using [HashiCorp Vault Agent Injector](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/injector):
```yaml
defaultConfigVolumeEnabled: false

podAnnotations:
  vault.hashicorp.com/agent-inject: "true"
  vault.hashicorp.com/role: "casdoor"
  vault.hashicorp.com/agent-init-first: "true"
  vault.hashicorp.com/agent-inject-default-template: json
  
  # Config file
  vault.hashicorp.com/agent-inject-secret-app.conf: "internal/data/infra/casdoor"
  vault.hashicorp.com/secret-volume-path-app.conf: "/conf"
  vault.hashicorp.com/agent-inject-template-app.conf: |-
    {{- with secret "internal/data/infra/casdoor" -}}
    {{- .Data.data.config -}}
    {{- end -}}
```

### Backward Compatibility
This change is fully backward compatible. Existing deployments will continue to work unchanged since `defaultConfigVolumeEnabled` defaults to `true`, preserving the current behavior.