### PR TITLE
feat: Make default config volume mount optional in Casdoor chart

### DIFF
--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -79,8 +79,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- if .Values.defaultConfigVolumeEnabled }}
             - name: config-volume
               mountPath: /conf
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -88,6 +90,7 @@ spec:
           {{- .Values.extraContainers | nindent 8 }}
         {{- end }}
       volumes:
+        {{- if .Values.defaultConfigVolumeEnabled }}
         - name: config-volume
           projected:
             defaultMode: 420
@@ -105,6 +108,7 @@ spec:
                     - key: app.conf
                       path: app.conf
             {{- end }}
+        {{- end }}
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -167,3 +167,7 @@ envFrom: []
   #   name: test-secret
 
 priorityClassName: ""
+
+# -- Enable/disable the default config volume mount to /conf
+# Set to false if you want to provide your own config volume via extraVolumes/extraVolumeMounts
+defaultConfigVolumeEnabled: true


### PR DESCRIPTION
_(I used the wrong git account for my first attempt in #38 so opened a new one to get the CLA signed properly)_

### Summary
This PR introduces a new configuration option `defaultConfigVolumeEnabled` that allows users to disable the default config volume mounting behavior, enabling them to provide their own custom config volume configuration via `extraVolumes` and `extraVolumeMounts`.

### Motivation
Currently, the Helm chart hardcodes the mounting of a `config-volume` to `/conf`, which creates limitations for users who need:
- Custom config volume sources (e.g., existing PVCs, external secret management)
- Integration with HashiCorp Vault Agent Injector for secret management
- More complex volume configurations (e.g., multiple config files from different sources)
- Different mounting paths or volume configurations
- External config management systems

Without this change, users cannot fully customize the config volume behavior since the default volume mount conflicts with or overrides their custom configurations.

### Changes
- **Added `defaultConfigVolumeEnabled` flag** in `values.yaml` (defaults to `true` for backward compatibility)
- **Made config volume mount conditional** in `deployment.yaml` template
- **Made config volume definition conditional** in `deployment.yaml` template
- **Added comprehensive documentation** for the new configuration option

### Usage Examples

#### Using existing PVC for config:
```yaml
defaultConfigVolumeEnabled: false

extraVolumes:
  - name: casdoor-config-pvc
    persistentVolumeClaim:
      claimName: casdoor-config-storage

extraVolumeMounts:
  - name: casdoor-config-pvc
    mountPath: /conf
    readOnly: true
```

#### Using HashiCorp Vault Agent Injector:
```yaml
defaultConfigVolumeEnabled: false

podAnnotations:
  vault.hashicorp.com/agent-inject: "true"
  vault.hashicorp.com/role: "casdoor"
  vault.hashicorp.com/agent-init-first: "true"
  vault.hashicorp.com/agent-inject-default-template: json
  
  # Config file
  vault.hashicorp.com/agent-inject-secret-app.conf: "internal/data/infra/casdoor"
  vault.hashicorp.com/secret-volume-path-app.conf: "/conf"
  vault.hashicorp.com/agent-inject-template-app.conf: |-
    {{- with secret "internal/data/infra/casdoor" -}}
    {{- .Data.data.config -}}
    {{- end -}}
```

### Backward Compatibility
This change is fully backward compatible. Existing deployments will continue to work unchanged since `defaultConfigVolumeEnabled` defaults to `true`, preserving the current behavior.