### PR TITLE
fix: secretName in projected volumes should be name

### DIFF
--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             sources:
             {{- if .Values.configFromSecret }}
               - secret:
-                  secretName: {{ .Values.configFromSecret }}
+                  name: {{ .Values.configFromSecret }}
                   items:
                     - key: app.conf
                       path: app.conf


### PR DESCRIPTION
See Kubernetes documentation for projected volumes: https://kubernetes.io/docs/concepts/storage/projected-volumes/#example-configuration-secrets-nondefault-permission-mode

> For secrets, the `secretName` field has been changed to `name` to be consistent with ConfigMap naming.