### PR TITLE
fix(helm): correct sqlite db path template and security context

### DIFF
--- a/charts/casdoor/templates/_helpers.tpl
+++ b/charts/casdoor/templates/_helpers.tpl
@@ -73,7 +73,6 @@ Create dataSourceName used in the configmap
 "user={{ .Values.database.user }} password={{ .Values.database.password }} host={{ .Values.database.host }} port={{ default "26257" .Values.database.port }} dbname={{ .Values.database.databaseName }} sslmode={{ .Values.database.sslMode }} serial_normalization=virtual_sequence"
 {{- else if .Values.persistence.enabled -}}
 file:/data/casdoor.db?cache=shared
-{{- end }}
 {{- else -}}
 file:casdoor.db?cache=shared
 {{- end }}

--- a/charts/casdoor/templates/deployment.yaml
+++ b/charts/casdoor/templates/deployment.yaml
@@ -27,11 +27,6 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "casdoor.serviceAccountName" . }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: "Always"
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{ if .Values.initContainersEnabled }}
       initContainers:
@@ -43,9 +38,6 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -126,7 +118,6 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "casdoor.fullname" . }}-data
         {{- end }}
-
         {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/casdoor/values.yaml
+++ b/charts/casdoor/values.yaml
@@ -73,8 +73,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: "Always"
 
 securityContext: {}
   # capabilities:


### PR DESCRIPTION
This commit addresses two issues:

1.  Corrects the logic in `_helpers.tpl` to ensure the correct database path is used when persistence is enabled.
2.  Refactors the `deployment.yaml` by moving the `podSecurityContext` to `values.yaml`. This makes the security context configurable and avoids hardcoding values, improving security and maintainability.

Fixes #43 and #42 